### PR TITLE
Add typings for mezzurite property in window

### DIFF
--- a/Mezzurite.Core/index.d.ts
+++ b/Mezzurite.Core/index.d.ts
@@ -1,0 +1,39 @@
+declare global {
+  interface Window {
+    mezzurite: {
+      EventElement: Element;
+      captureCycleStarted: boolean;
+      captureTimer: function;
+      defaultLogs: Array<object>;
+      elementLookup: object;
+      endTime: number;
+      firstViewLoaded: boolean;
+      measures: Array<{
+        clt: number;
+        endTime: number;
+        id: string;
+        name: string;
+        slowResource: {
+          endTime: number;
+          name: string;
+        };
+        startTime: number;
+        untilMount: number;
+      }>;
+      packageName: string;
+      packageVersion: string;
+      routeUrl: string;
+      routerPerf: boolean;
+      slowestResource: {
+        endTime: number;
+        name: string;
+      };
+      startTime: number;
+      viewportHeight: number;
+      viewportWidth: number;
+      vltComponentLookup: object;
+    }
+  }
+}
+
+export default global;

--- a/Mezzurite.Core/tsconfig.json
+++ b/Mezzurite.Core/tsconfig.json
@@ -16,7 +16,8 @@
           "dom"
       ],
       "typeRoots": [
-          "node_modules/@types/"
+          "node_modules/@types/",
+          "./index.d.ts"
       ]
   },
   "exclude": [


### PR DESCRIPTION
This adds the `window.mezzurite` typing so that we won't have to deal with `(window as any).mezzurite` anymore. We can go about cleaning up those declarations in a future PR.