### PR TITLE
Prep for publishing to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,5 @@
 
 With Mezzurite, you can track how long your UI components are taking to render. You're free to transform, stream, read, or log the results however you'd like.
 
-## Getting Started
-Coming soon.
-
 ## v1.x (Legacy)
 For the legacy version of Mezzurite, please visit the [v1.x branch](https://github.com/microsoft/Mezzurite/tree/v1.x).
-
-## Documentation
-Coming soon.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+<p align="center">
+  <a href="https://microsoft.github.io/mezzurite">
+		<img alt="Mezzurite Logo" src="https://raw.githubusercontent.com/microsoft/Mezzurite/v1.x/docs/images/Mezzurite_yellow.svg" width="546px">
+  </a>
+</p>
+
+<h2 align="center">
+  <a href="https://microsoft.github.io/mezzurite">Your components, timed.</a>
+</h2>
+
+<a href="https://badge.fury.io/js/%40microsoft%2Fmezzurite-core">
+  <img src="https://badge.fury.io/js/%40microsoft%2Fmezzurite-core.svg" alt="npm version" height="18">
+</a>
+
+With Mezzurite, you can track how long your UI components are taking to render. You're free to transform, stream, read, or log the results however you'd like.
+
+## Getting Started
+Coming soon.
+
+## v1.x (Legacy)
+For the legacy version of Mezzurite, please visit the [v1.x branch](https://github.com/microsoft/Mezzurite/tree/v1.x).
+
+## Documentation
+Coming soon.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "unpkg": "./dist/mezzurite.js",
   "module": "es/mezzurite.js",
   "author": "Microsoft Corporation",
+  "files": [
+    "dist",
+    "lib",
+    "es",
+    "src",
+    "index.d.ts"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Microsoft/Mezzurite.git"


### PR DESCRIPTION
Publishing to npm means we need to have a functioning README as well as the specified tarball contents in `package.json`.

Addresses #55.