### PR TITLE
State transition validations for onComponentStart

### DIFF
--- a/src/listeners/onComponentStart.js
+++ b/src/listeners/onComponentStart.js
@@ -13,6 +13,8 @@ function onComponentStart (event) {
         name: event.detail.name,
         startTime
       }));
+    } else {
+      console.warn(`COMPONENT_START emitted for existing component id: ${event.detail.id}`);
     }
   }
 }

--- a/src/listeners/onComponentStart.js
+++ b/src/listeners/onComponentStart.js
@@ -3,12 +3,17 @@ import store from '../store';
 
 function onComponentStart (event) {
   if (event != null && event.detail != null) {
-    const startTime = performance.now();
-    store.dispatch(componentStart({
-      id: event.detail.id,
-      name: event.detail.name,
-      startTime
-    }));
+    const state = store.getState();
+
+    if (!(event.detail.id in state)) {
+      // A COMPONENT_START action has not been dispatched yet for this id
+      const startTime = performance.now();
+      store.dispatch(componentStart({
+        id: event.detail.id,
+        name: event.detail.name,
+        startTime
+      }));
+    }
   }
 }
 

--- a/src/listeners/onComponentStart.test.js
+++ b/src/listeners/onComponentStart.test.js
@@ -9,59 +9,63 @@ describe('onComponentStart.js', () => {
     store.getState = jest.fn(() => ({}));
   });
 
-  it('should not dispatch when the event is null', () => {
-    onComponentStart(null);
-
-    expect(store.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('should not dispatch when the event is undefined', () => {
-    onComponentStart(undefined);
-
-    expect(store.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('should not dispatch when the event detail is null', () => {
-    onComponentStart({
-      detail: null
+  describe('invalid events', () => {
+    it('should not dispatch when the event is null', () => {
+      onComponentStart(null);
+  
+      expect(store.dispatch).not.toHaveBeenCalled();
     });
-
-    expect(store.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('should not dispatch when the event detail is undefined', () => {
-    onComponentStart({
-      detail: undefined
+  
+    it('should not dispatch when the event is undefined', () => {
+      onComponentStart(undefined);
+  
+      expect(store.dispatch).not.toHaveBeenCalled();
     });
-
-    expect(store.dispatch).not.toHaveBeenCalled();
+  
+    it('should not dispatch when the event detail is null', () => {
+      onComponentStart({
+        detail: null
+      });
+  
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  
+    it('should not dispatch when the event detail is undefined', () => {
+      onComponentStart({
+        detail: undefined
+      });
+  
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('should not dispatch when the component id already exists in the store', () => {
-    store.getState = jest.fn(() => ({'id': {}}));
-    onComponentStart({
-      detail: {
+  describe('valid events', () => {
+    it('should not dispatch when the component id already exists in the store', () => {
+      store.getState = jest.fn(() => ({'id': {}}));
+      onComponentStart({
+        detail: {
+          id: 'id',
+          name: 'name'
+        }
+      });
+  
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  
+    it('should dispatch the component data to the store', () => {
+      performance.now = jest.fn(() => 5);
+      onComponentStart({
+        detail: {
+          id: 'id',
+          name: 'name'
+        }
+      });
+  
+      expect(store.dispatch).toHaveBeenCalledWith(componentStart({
         id: 'id',
-        name: 'name'
-      }
+        name: 'name',
+        startTime: 5
+      }));
     });
-
-    expect(store.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('should dispatch the component data to the store', () => {
-    performance.now = jest.fn(() => 5);
-    onComponentStart({
-      detail: {
-        id: 'id',
-        name: 'name'
-      }
-    });
-
-    expect(store.dispatch).toHaveBeenCalledWith(componentStart({
-      id: 'id',
-      name: 'name',
-      startTime: 5
-    }));
   });
 });

--- a/src/listeners/onComponentStart.test.js
+++ b/src/listeners/onComponentStart.test.js
@@ -6,6 +6,7 @@ describe('onComponentStart.js', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     store.dispatch = jest.fn();
+    store.getState = jest.fn(() => ({}));
   });
 
   it('should not dispatch when the event is null', () => {
@@ -31,6 +32,18 @@ describe('onComponentStart.js', () => {
   it('should not dispatch when the event detail is undefined', () => {
     onComponentStart({
       detail: undefined
+    });
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('should not dispatch when the component id already exists in the store', () => {
+    store.getState = jest.fn(() => ({'id': {}}));
+    onComponentStart({
+      detail: {
+        id: 'id',
+        name: 'name'
+      }
     });
 
     expect(store.dispatch).not.toHaveBeenCalled();

--- a/src/listeners/onComponentStart.test.js
+++ b/src/listeners/onComponentStart.test.js
@@ -19,47 +19,47 @@ describe('onComponentStart.js', () => {
   describe('invalid events', () => {
     it('should not dispatch when the event is null', () => {
       onComponentStart(null);
-  
+
       expect(store.dispatch).not.toHaveBeenCalled();
     });
-  
+
     it('should not dispatch when the event is undefined', () => {
       onComponentStart(undefined);
-  
+
       expect(store.dispatch).not.toHaveBeenCalled();
     });
-  
+
     it('should not dispatch when the event detail is null', () => {
       onComponentStart({
         detail: null
       });
-  
+
       expect(store.dispatch).not.toHaveBeenCalled();
     });
-  
+
     it('should not dispatch when the event detail is undefined', () => {
       onComponentStart({
         detail: undefined
       });
-  
+
       expect(store.dispatch).not.toHaveBeenCalled();
     });
   });
 
   describe('valid events', () => {
     it('should not dispatch when the component id already exists in the store', () => {
-      store.getState = jest.fn(() => ({'id': {}}));
+      store.getState = jest.fn(() => ({ 'id': {} }));
       onComponentStart({
         detail: {
           id: 'id',
           name: 'name'
         }
       });
-      
+
       expect(store.dispatch).not.toHaveBeenCalled();
       expect(spyWarn).toHaveBeenCalled();
     });
-  
+
     it('should dispatch the component data to the store', () => {
       performance.now = jest.fn(() => 5);
       onComponentStart({
@@ -68,7 +68,7 @@ describe('onComponentStart.js', () => {
           name: 'name'
         }
       });
-  
+
       expect(store.dispatch).toHaveBeenCalledWith(componentStart({
         id: 'id',
         name: 'name',

--- a/src/listeners/onComponentStart.test.js
+++ b/src/listeners/onComponentStart.test.js
@@ -2,11 +2,18 @@ import { componentStart } from '../actions/components';
 import store from '../store';
 import onComponentStart from './onComponentStart';
 
+let spyWarn = null;
+
 describe('onComponentStart.js', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     store.dispatch = jest.fn();
     store.getState = jest.fn(() => ({}));
+    spyWarn = jest.spyOn(console, 'warn');
+  });
+
+  afterEach(() => {
+    spyWarn.mockRestore();
   });
 
   describe('invalid events', () => {
@@ -48,8 +55,9 @@ describe('onComponentStart.js', () => {
           name: 'name'
         }
       });
-  
+      
       expect(store.dispatch).not.toHaveBeenCalled();
+      expect(spyWarn).toHaveBeenCalled();
     });
   
     it('should dispatch the component data to the store', () => {


### PR DESCRIPTION
This set of changes ensures that the `COMPONENT_START` action is not dispatched  when the store already contains an entry for the component id present in the event. Further, the event handler will issue a warning via `console.warn()` to aid developers in debugging these failed state transitions.

The corresponding unit test suite has been updated to enforce this specification.

Addresses part of #54.