### PR TITLE
Add empty mock implementation for console.warn

### DIFF
--- a/src/listeners/onComponentEnd.test.js
+++ b/src/listeners/onComponentEnd.test.js
@@ -9,7 +9,7 @@ describe('onComponentEnd.js', () => {
     jest.clearAllMocks();
     store.dispatch = jest.fn();
     store.getState = jest.fn(() => ({}));
-    spyWarn = jest.spyOn(console, 'warn');
+    spyWarn = jest.spyOn(console, 'warn').mockImplementation();
   });
 
   afterEach(() => {

--- a/src/listeners/onComponentStart.test.js
+++ b/src/listeners/onComponentStart.test.js
@@ -9,7 +9,7 @@ describe('onComponentStart.js', () => {
     jest.clearAllMocks();
     store.dispatch = jest.fn();
     store.getState = jest.fn(() => ({}));
-    spyWarn = jest.spyOn(console, 'warn');
+    spyWarn = jest.spyOn(console, 'warn').mockImplementation();
   });
 
   afterEach(() => {


### PR DESCRIPTION
When the tests run, we swallow the console warnings that we're expecting to be called so any warnings we see are more meaningful, preventing something like this:

```sh
PASS src/listeners/onComponentEnd.test.js
  ● Console

    console.warn node_modules/jest-mock/build/index.js:860
      COMPONENT_END emitted before COMPONENT_START for component id: id
    console.warn node_modules/jest-mock/build/index.js:860
      COMPONENT_END emitted for component id with end time: id

PASS src/listeners/onComponentStart.test.js
  ● Console

    console.warn node_modules/jest-mock/build/index.js:860
      COMPONENT_START emitted for existing component id: id

PASS src/reducers/components.test.js
PASS src/events/dispatchComponentsChanged.test.js
PASS src/listeners/onComponentRemove.test.js
```